### PR TITLE
Remove useless class existence check

### DIFF
--- a/src/ServiceContainer/Driver/PhantomJSFactory.php
+++ b/src/ServiceContainer/Driver/PhantomJSFactory.php
@@ -51,11 +51,6 @@ class PhantomJSFactory implements DriverFactory {
    * @return Definition
    */
   public function buildDriver(array $config) {
-    if (!class_exists('Zumba\Mink\Driver\PhantomJSDriver')) {
-      throw new \RuntimeException(
-        'Install PhantomJSDriver in order to use phantomjs driver.'
-      );
-    }
     return new Definition('Zumba\Mink\Driver\PhantomJSDriver',
       array($config["phantom_server"], $config["template_cache"])
     );


### PR DESCRIPTION
The extension has a dependency on the driver in the composer metadata, so the driver class will always be installed.
